### PR TITLE
Fix attribute error on setting max_len in tokenization_hanbert

### DIFF
--- a/tokenization_hanbert.py
+++ b/tokenization_hanbert.py
@@ -401,10 +401,14 @@ class HanBertTokenizer(PreTrainedTokenizer):
         """
         super(HanBertTokenizer, self).__init__(unk_token=unk_token, sep_token=sep_token,
                                                pad_token=pad_token, cls_token=cls_token,
-                                               mask_token=mask_token, **kwargs)
-        self.max_len = 512  # hard-coded
-        self.max_len_single_sentence = self.max_len - 2  # take into account special tokens
-        self.max_len_sentences_pair = self.max_len - 3  # take into account special tokens
+                                               mask_token=mask_token, model_max_length=512, 
+                                               **kwargs)
+
+        # Commenting out below codes for preventing attribute error
+        # Instead, set up the max len(currently model_max_len) in super
+        # self.max_len = 512  # hard-coded
+        # self.max_len_single_sentence = self.max_len - 2  # take into account special tokens
+        # self.max_len_sentences_pair = self.max_len - 3  # take into account special tokens
 
         if not os.path.isfile(vocab_file):
             raise ValueError(


### PR DESCRIPTION
* HanBertTokenizer.__init__()에서 max_len을 setting하는 경우, 아래 error가 발생함
```python
 "AttributeError: can't set attribute"
```

* max_len은 super init에서 정의가 가능하여 수정된 코드와 같이 변경하였습니다.